### PR TITLE
Drupal

### DIFF
--- a/config/apache/sites-available/001-dynamic-vhost-dp8.conf
+++ b/config/apache/sites-available/001-dynamic-vhost-dp8.conf
@@ -2,16 +2,18 @@
 UseCanonicalName Off
 
 <VirtualHost *:80>
-    # Catch only requests to ezdev domains.
     ServerName dp8
-    ServerAlias *.dp8
-    ServerAlias *.*.dp8
+    # Alway use the second domain component as the target folder name
+    ServerAlias *.*.dp8 # www.site-name.dp8
+    ServerAlias *.*.*.dp8 # www.site-name.*.dp8
+    ServerAlias *.*.*.loc # www.site-name.*.loc
+    ServerAlias *.*.*.*.loc # www.site-name.machine-name.dev.loc
     ServerAdmin dp8@kaliop.com
 
     #SetEnv ENVIRONMENT "dev"
     SetEnvIf Request_Method .* ENVIRONMENT=dev
     SetEnv USE_HTTP_CACHE 0
-	SetEnv TRUSTED_PROXIES "varnish"
+    SetEnv TRUSTED_PROXIES "varnish"
 
     # Log everything so its sortable by domain name.
     LogFormat "%V %h %t \"%r\" %s %b" vcommon
@@ -21,7 +23,7 @@ UseCanonicalName Off
     ErrorLog ${APACHE_LOG_DIR}/error.log
 
     # Use the first part of the domain name as folder name to look in.
-    VirtualDocumentRoot /var/www/%-2/web
+    VirtualDocumentRoot /var/www/%2/web
 
     DirectoryIndex index.php
     UseCanonicalName Off
@@ -43,15 +45,17 @@ UseCanonicalName Off
 </VirtualHost>
 
 <VirtualHost *:82>
-    # Catch only requests to ezdev domains.
     ServerName dp8
-    ServerAlias *.dp8
-    ServerAlias *.*.dp8
+    # Alway use the second domain component as the target folder name
+    ServerAlias *.*.dp8 # www.site-name.dp8
+    ServerAlias *.*.*.dp8 # www.site-name.*.dp8
+    ServerAlias *.*.*.loc # www.site-name.*.loc
+    ServerAlias *.*.*.*.loc # www.site-name.machine-name.dev.loc
     ServerAdmin dp8@kaliop.com
 
     SetEnvIf Request_Method .* ENVIRONMENT=demo
     SetEnv USE_HTTP_CACHE 0
-	SetEnv TRUSTED_PROXIES "varnish"
+    SetEnv TRUSTED_PROXIES "varnish"
 
     # Log everything so its sortable by domain name.
     LogFormat "%V %h %t \"%r\" %s %b" vcommon
@@ -62,7 +66,7 @@ UseCanonicalName Off
     CustomLog ${APACHE_LOG_DIR}/demo-site_access.log vcommon
 
     # Use the first part of the domain name as folder name to look in.
-    VirtualDocumentRoot /var/www/%-2/web
+    VirtualDocumentRoot /var/www/%2/web
 
     DirectoryIndex index.php
     UseCanonicalName Off

--- a/config/apache/sites-available/001-dynamic-vhost-dp8.conf
+++ b/config/apache/sites-available/001-dynamic-vhost-dp8.conf
@@ -6,6 +6,7 @@ UseCanonicalName Off
     # Alway use the second domain component as the target folder name
     ServerAlias *.*.dp8 # www.site-name.dp8
     ServerAlias *.*.*.dp8 # www.site-name.*.dp8
+    ServerAlias *.*.loc # www.site-name.loc
     ServerAlias *.*.*.loc # www.site-name.*.loc
     ServerAlias *.*.*.*.loc # www.site-name.machine-name.dev.loc
     ServerAdmin dp8@kaliop.com
@@ -49,6 +50,7 @@ UseCanonicalName Off
     # Alway use the second domain component as the target folder name
     ServerAlias *.*.dp8 # www.site-name.dp8
     ServerAlias *.*.*.dp8 # www.site-name.*.dp8
+    ServerAlias *.*.loc # www.site-name.loc
     ServerAlias *.*.*.loc # www.site-name.*.loc
     ServerAlias *.*.*.*.loc # www.site-name.machine-name.dev.loc
     ServerAdmin dp8@kaliop.com

--- a/config/apache/sites-available/001-dynamic-vhost-dp8.conf
+++ b/config/apache/sites-available/001-dynamic-vhost-dp8.conf
@@ -6,7 +6,6 @@ UseCanonicalName Off
     ServerName dp8
     ServerAlias *.dp8
     ServerAlias *.*.dp8
-    ServerAlias *.*.*.dev.loc
     ServerAdmin dp8@kaliop.com
 
     #SetEnv ENVIRONMENT "dev"
@@ -22,7 +21,7 @@ UseCanonicalName Off
     ErrorLog ${APACHE_LOG_DIR}/error.log
 
     # Use the first part of the domain name as folder name to look in.
-    VirtualDocumentRoot /var/www
+    VirtualDocumentRoot /var/www/%-2/web
 
     DirectoryIndex index.php
     UseCanonicalName Off
@@ -48,7 +47,6 @@ UseCanonicalName Off
     ServerName dp8
     ServerAlias *.dp8
     ServerAlias *.*.dp8
-    ServerAlias *.*.*.dev.loc
     ServerAdmin dp8@kaliop.com
 
     SetEnvIf Request_Method .* ENVIRONMENT=demo
@@ -64,7 +62,7 @@ UseCanonicalName Off
     CustomLog ${APACHE_LOG_DIR}/demo-site_access.log vcommon
 
     # Use the first part of the domain name as folder name to look in.
-    VirtualDocumentRoot /var/www
+    VirtualDocumentRoot /var/www/%-2/web
 
     DirectoryIndex index.php
     UseCanonicalName Off

--- a/docker-compose-frontend-template.yml
+++ b/docker-compose-frontend-template.yml
@@ -15,8 +15,8 @@ services:
         ports:
             - "80:80"
         volumes:
-            - ./config/apache/sites-available/001-dynamic-vhost-ez5.conf:/etc/apache2/sites-available/001-dynamic-vhost-ez5.conf
-            - ./config/apache/sites-available/ez5-common.conf:/etc/apache2/sites-available/ez5-common.conf
+            - ./config/apache/sites-available/001-dynamic-vhost-dp8.conf:/etc/apache2/sites-available/001-dynamic-vhost-dp8.conf
+            - ./config/apache/sites-available/dp8-common.conf:/etc/apache2/sites-available/dp8-common.conf
             - ./logs/apache/:/var/log/apache2
             - "./config/apache/php5/custom_vars.ini:$DOCKER_PHP_CONF_PATH/apache2/conf.d/custom_vars.ini"
             - "./config/apache/php5/timezone.ini:$DOCKER_PHP_CONF_PATH/apache2/conf.d/timezone.ini"

--- a/images/apache_php54/bootstrap.sh
+++ b/images/apache_php54/bootstrap.sh
@@ -36,19 +36,9 @@ chown -R site:site /var/lock/apache2
 
 echo [`date`] Starting the service
 
-#Load ez5 dynamic vhost (including common config) if files are found
-if [ -f "/etc/apache2/sites-available/001-dynamic-vhost-ez5.conf" ] && [ -f "/etc/apache2/sites-available/ez5-common.conf" ];then
-    a2ensite 001-dynamic-vhost-ez5.conf
-fi
-
-#Load ezplatform dynamic vhost (including common config) if files are found
-if [ -f "/etc/apache2/sites-available/002-dynamic-vhost-ezplatform.conf" ] && [ -f "/etc/apache2/sites-available/ezplatform-common.conf" ];then
-    a2ensite 002-dynamic-vhost-ezplatform.conf
-fi
-
-#Load ez4 dynamic vhost if found
-if [ -f "/etc/apache2/sites-available/003-dynamic-vhost-ez4.conf" ];then
-    a2ensite 003-dynamic-vhost-ez4.conf
+#Load dp8 dynamic vhost (including common config) if files are found
+if [ -f "/etc/apache2/sites-available/001-dynamic-vhost-dp8.conf" ] && [ -f "/etc/apache2/sites-available/dp8-common.conf" ];then
+	a2ensite 001-dynamic-vhost-dp8.conf
 fi
 
 trap clean_up SIGTERM

--- a/images/apache_php56/bootstrap.sh
+++ b/images/apache_php56/bootstrap.sh
@@ -36,9 +36,9 @@ chown -R site:site /var/lock/apache2
 
 echo [`date`] Starting the service
 
-#Load dynamic vhost (including common config) if files are found
+#Load dp8 dynamic vhost (including common config) if files are found
 if [ -f "/etc/apache2/sites-available/001-dynamic-vhost-dp8.conf" ] && [ -f "/etc/apache2/sites-available/dp8-common.conf" ];then
-	a2ensite 001-dynamic-vhost-ez5.conf
+	a2ensite 001-dynamic-vhost-dp8.conf
 fi
 
 

--- a/images/apache_php7/bootstrap.sh
+++ b/images/apache_php7/bootstrap.sh
@@ -36,21 +36,10 @@ chown -R site:site /var/lock/apache2
 
 echo [`date`] Starting the service
 
-#Load ez5 dynamic vhost (including common config) if files are found
-if [ -f "/etc/apache2/sites-available/001-dynamic-vhost-ez5.conf" ] && [ -f "/etc/apache2/sites-available/ez5-common.conf" ];then
-	a2ensite 001-dynamic-vhost-ez5.conf
+#Load dp8 dynamic vhost (including common config) if files are found
+if [ -f "/etc/apache2/sites-available/001-dynamic-vhost-dp8.conf" ] && [ -f "/etc/apache2/sites-available/dp8-common.conf" ];then
+	a2ensite 001-dynamic-vhost-dp8.conf
 fi
-
-#Load ezplatform dynamic vhost (including common config) if files are found
-if [ -f "/etc/apache2/sites-available/002-dynamic-vhost-ezplatform.conf" ] && [ -f "/etc/apache2/sites-available/ezplatform-common.conf" ];then
-    a2ensite 002-dynamic-vhost-ezplatform.conf
-fi
-
-#Load ez4 dynamic vhost if found
-if [ -f "/etc/apache2/sites-available/003-dynamic-vhost-ez4.conf" ];then
-    a2ensite 003-dynamic-vhost-ez4.conf
-fi
-
 
 trap clean_up SIGTERM
 


### PR DESCRIPTION
Changes from eZ config were:

- Rename Apache vhost config files.
- Nullify VirtualDocumentRoot, always serving `/var/www` instead of `/var/www/[main domain component]/web`.
- Matching config done for the php56 image only.

This PR:

- Restores the dynamic VirtualDocumentRoot.
- Makes sure the config filename changes are reflected in the php7 and php54 images.
- Actually load the right vhost file for the php56 branch (test filenames and ad2ensite command were mismatched).

With this vhost config, one should use URLs like these:

```
http://www.site-name.dp8
http://other.site-name.dp8
http://www.site-name.whatever.dp8
http://x.site-name.loc
http://y.site-name.domain1.loc
http://z.site-name.domain1.domain2.loc
```

In all cases, the second fragment from the domain (starting from the left) is used to serve this directory:

```
/var/www/site-name/web
```
